### PR TITLE
Fix return item on admin-order

### DIFF
--- a/views/templates/hook/admin-order.tpl
+++ b/views/templates/hook/admin-order.tpl
@@ -128,7 +128,7 @@
 
                             </div>
                         </div>
-                    {elseif $avardaStatus === 2 and $avardaRemaining > 0}
+                    {elseif $avardaStatus === 2}
                         <div class="form form-infline">
                             <h4>{l s='Return item' mod='avardapayments'}</h4>
                             <input type="text" id="avarda-return" name="avarda-return"


### PR DESCRIPTION
Return item/order method is called on orders that have been captured already - hence $avardaRemaining is almost always 0. 

So 

> and $avardaRemaining > 0 

makes no sense here.