### PR TITLE
Fix Avarda purchase token length in DB, 300 not enough

### DIFF
--- a/sql/install.sql
+++ b/sql/install.sql
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS `PREFIX_avarda_session` (
   `id_cart`          INT(11) UNSIGNED NOT NULL,
   `id_order`         INT(11) UNSIGNED NULL,
   `purchase_id`      VARCHAR(64) NOT NULL,
-  `purchase_token`   VARCHAR(300) NOT NULL,
+  `purchase_token`   VARCHAR(1000) NOT NULL,
   `purchase_expire_timestamp` DATETIME,
   `cart_signature`   VARCHAR(64) NOT NULL,
   `status`           VARCHAR(20) NOT NULL,


### PR DESCRIPTION
Avarda has changed the length of the Jwt token, resulting in PrestaShop DB not being able to store the full Jwt token.

This does not fix the existing installs, need to alter the avarda_session table.

`ALTER TABLE "ps_avarda_session" MODIFY COLUMN "purchase_token" VARCHAR(1000) NOT NULL;`

or similar.