### PR TITLE
Fix limited token length - bump to 4.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+20250303 - Avarda Team
+========
+* Edited changelog
+* Increased collumn size for purchase_token from VARCHAR(300) to VARCHAR(1000)
+* Updated README.md to notify users about the module only supporting PrestaShop 1.7
+* Changed version number to 4.3.0 for next release
+
+
 20230203 - revulondigital
 ========
 * Edited changelog

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Avarda-Payments
 
-Avardas' payment module for Prestashop.
+Avardas' payment module for Prestashop. This module is only compatible with Prestashop 1.7.
 
 ### Language settings
 

--- a/avardapayments.php
+++ b/avardapayments.php
@@ -59,7 +59,7 @@ class AvardaPayments extends PaymentModule
     {
         $this->name = 'avardapayments';
         $this->tab = 'payments_gateways';
-        $this->version = '4.2.1';
+        $this->version = '4.3.0';
         $this->author = 'DataKick, Loiki';
         $this->need_instance = 0;
         $this->bootstrap = true;

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS `PREFIX_avarda_session` (
   `id_cart`          INT(11) UNSIGNED NOT NULL,
   `id_order`         INT(11) UNSIGNED NULL,
   `purchase_id`      VARCHAR(64) NOT NULL,
-  `purchase_token`   VARCHAR(300) NOT NULL,
+  `purchase_token`   VARCHAR(1000) NOT NULL,
   `purchase_expire_timestamp` DATETIME,
   `cart_signature`   VARCHAR(64) NOT NULL,
   `status`           VARCHAR(20) NOT NULL,

--- a/upgrade/install-4.3.0.php
+++ b/upgrade/install-4.3.0.php
@@ -1,0 +1,17 @@
+<?php
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_4_3_0(AvardaPayments $module)
+{
+    $query = '
+        ALTER TABLE `' . _DB_PREFIX_ . 'avarda_session`
+        MODIFY COLUMN `purchase_token` VARCHAR(1000) NOT NULL;
+    ';
+
+    if (!Db::getInstance()->execute($query)) {
+        return false;
+    }
+}


### PR DESCRIPTION
* Edited changelog
* Increased collumn size for purchase_token from VARCHAR(300) to VARCHAR(1000)
* Updated README.md to notify users about the module only supporting PrestaShop 1.7
* Changed version number to 4.3.0 for next release